### PR TITLE
Less restrictive host in configuration, added ability to show rule description

### DIFF
--- a/src/main/java/org/sonar/ide/intellij/component/SonarModuleComponentImpl.java
+++ b/src/main/java/org/sonar/ide/intellij/component/SonarModuleComponentImpl.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.module.ModuleComponent;
 import org.jetbrains.annotations.NotNull;
+import org.sonar.ide.intellij.utils.SonarUtils;
 import org.sonar.wsclient.Host;
 import org.sonar.wsclient.Sonar;
 import org.sonar.wsclient.connectors.HttpClient4Connector;
@@ -55,7 +56,7 @@ public class SonarModuleComponentImpl implements SonarModuleComponent, ModuleCom
 
   @Override
   public Sonar getSonar() {
-    return new Sonar(new HttpClient4Connector(new Host(myState.host, myState.user, myState.password)));
+    return new Sonar(new HttpClient4Connector(new Host(SonarUtils.fixHostName(myState.host), myState.user, myState.password)));
   }
 
   @Override

--- a/src/main/java/org/sonar/ide/intellij/component/SonarProjectComponent.java
+++ b/src/main/java/org/sonar/ide/intellij/component/SonarProjectComponent.java
@@ -1,6 +1,7 @@
 package org.sonar.ide.intellij.component;
 
 import org.sonar.ide.intellij.model.ToolWindowModel;
+import org.sonar.wsclient.Sonar;
 
 public interface SonarProjectComponent {
   SonarProjectState getState();
@@ -13,4 +14,5 @@ public interface SonarProjectComponent {
   }
   void setToolWindowModel(ToolWindowModel model);
   ToolWindowModel getToolWindowModel();
+  Sonar getSonar();
 }

--- a/src/main/java/org/sonar/ide/intellij/component/SonarProjectComponentImpl.java
+++ b/src/main/java/org/sonar/ide/intellij/component/SonarProjectComponentImpl.java
@@ -9,6 +9,10 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.sonar.ide.intellij.listener.SonarFileEditorManagerListener;
 import org.sonar.ide.intellij.model.ToolWindowModel;
+import org.sonar.ide.intellij.utils.SonarUtils;
+import org.sonar.wsclient.Host;
+import org.sonar.wsclient.Sonar;
+import org.sonar.wsclient.connectors.HttpClient4Connector;
 
 @State(name = "SonarConfiguration", storages = {@Storage(id = "other", file = "$PROJECT_FILE$")})
 public class SonarProjectComponentImpl implements SonarProjectComponent, ProjectComponent, PersistentStateComponent<SonarProjectComponent.SonarProjectState> {
@@ -62,5 +66,10 @@ public class SonarProjectComponentImpl implements SonarProjectComponent, Project
   @Override
   public void setToolWindowModel(ToolWindowModel model) {
     this.toolWindowModel = model;
+  }
+
+  @Override
+  public Sonar getSonar() {
+    return new Sonar(new HttpClient4Connector(new Host(SonarUtils.fixHostName(state.host), state.user, state.password)));
   }
 }

--- a/src/main/java/org/sonar/ide/intellij/listener/RefreshRuleListener.java
+++ b/src/main/java/org/sonar/ide/intellij/listener/RefreshRuleListener.java
@@ -1,0 +1,10 @@
+package org.sonar.ide.intellij.listener;
+
+
+import org.sonar.wsclient.services.Rule;
+
+import java.util.List;
+
+public interface RefreshRuleListener {
+  void doneRefreshRules(List<Rule> rules);
+}

--- a/src/main/java/org/sonar/ide/intellij/model/SonarTreeModel.java
+++ b/src/main/java/org/sonar/ide/intellij/model/SonarTreeModel.java
@@ -143,7 +143,7 @@ public class SonarTreeModel implements TreeModel {
           }
         });
         if (ruleLabel == null) {
-          ruleLabel = new RuleLabel(ruleName, violation.getSeverity());
+          ruleLabel = new RuleLabel(ruleName, violation.getSeverity(), violation.getRuleKey());
           ruleLabels.add(ruleLabel);
           fileLabelsMap.put(ruleLabel, new LinkedList<FileLabel>());
         }
@@ -228,10 +228,12 @@ public class SonarTreeModel implements TreeModel {
   public class RuleLabel {
     private String ruleName;
     private String severity;
+    private String ruleKey;
 
-    public RuleLabel(String ruleName, String severity) {
+    public RuleLabel(String ruleName, String severity, String ruleKey) {
       this.ruleName = ruleName;
       this.severity = severity;
+      this.ruleKey = ruleKey;
     }
 
     public String toString() {
@@ -244,6 +246,10 @@ public class SonarTreeModel implements TreeModel {
 
     public String getSeverity() {
       return severity;
+    }
+
+    public String getRuleKey() {
+      return ruleKey;
     }
   }
 

--- a/src/main/java/org/sonar/ide/intellij/ui/TreeMousePressedListener.java
+++ b/src/main/java/org/sonar/ide/intellij/ui/TreeMousePressedListener.java
@@ -1,0 +1,26 @@
+package org.sonar.ide.intellij.ui;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import org.jdesktop.swingx.JXTree;
+import org.sonar.ide.intellij.model.SonarTreeModel;
+
+import javax.swing.tree.TreePath;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class TreeMousePressedListener extends MouseAdapter {
+  private final JXTree tree;
+  private final AnAction displayDescriptionAction;
+
+  public TreeMousePressedListener(JXTree tree, AnAction displayDescriptionAction) {
+    this.tree = tree;
+    this.displayDescriptionAction = displayDescriptionAction;
+  }
+  @Override
+  public void mousePressed(MouseEvent e) {
+    TreePath p = tree.getPathForLocation(e.getX(), e.getY());
+    if (p != null && !p.equals(tree.getSelectionModel().getSelectionPath()))
+      tree.getSelectionModel().setSelectionPath(p);
+    displayDescriptionAction.getTemplatePresentation().setVisible(p != null && p.getLastPathComponent() instanceof SonarTreeModel.RuleLabel);
+  }
+}

--- a/src/main/java/org/sonar/ide/intellij/utils/SonarUtils.java
+++ b/src/main/java/org/sonar/ide/intellij/utils/SonarUtils.java
@@ -1,0 +1,12 @@
+package org.sonar.ide.intellij.utils;
+
+public class SonarUtils {
+  public static String fixHostName(String hostName) {
+    String host = hostName;
+    if (host.indexOf("://") == -1)
+      host = "http://" + host;
+    if (host.charAt(host.length()-1) == '/')
+      host = host.substring(0, host.length()-1);
+    return host;
+  }
+}

--- a/src/main/java/org/sonar/ide/intellij/worker/RefreshRuleWorker.java
+++ b/src/main/java/org/sonar/ide/intellij/worker/RefreshRuleWorker.java
@@ -1,0 +1,48 @@
+package org.sonar.ide.intellij.worker;
+
+import com.intellij.openapi.project.Project;
+import org.sonar.ide.intellij.component.SonarProjectComponent;
+import org.sonar.ide.intellij.listener.RefreshRuleListener;
+import org.sonar.wsclient.Sonar;
+import org.sonar.wsclient.services.Rule;
+import org.sonar.wsclient.services.RuleQuery;
+
+import javax.swing.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class RefreshRuleWorker extends SwingWorker<List<Rule>, Void> {
+  private Project project;
+
+  private List<RefreshRuleListener> listeners = new LinkedList<RefreshRuleListener>();
+
+  public RefreshRuleWorker(Project project) {
+    this.project = project;
+  }
+
+  @Override
+  protected List<Rule> doInBackground() throws Exception {
+    SonarProjectComponent component = project.getComponent(SonarProjectComponent.class);
+    Sonar sonar = component.getSonar();
+    return sonar.findAll(new RuleQuery("java"));
+  }
+
+  @Override
+  protected void done() {
+    try {
+      List<Rule> rules = get();
+      for (RefreshRuleListener listener : listeners)
+        listener.doneRefreshRules(rules);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public void addListener(RefreshRuleListener listener) {
+    listeners.add(listener);
+  }
+
+}


### PR DESCRIPTION
I've added new features to plugin:
- Checking if host name contains ://, if not prepending string http:// to host; and deleting last slash if present in host string,
- Showing rule description by action in context menu (not available in table view). Rule descriptors are downloaded from sonar server configured in project configuration at the first show of sonar window, or if it will return empty list, at next "Show description" action perform.
